### PR TITLE
Update default logout_icon to new Font Awesome 6 name

### DIFF
--- a/settings.yml
+++ b/settings.yml
@@ -1,5 +1,5 @@
 logout_icon:
-  default: "sign-out-alt"
+  default: "right-from-bracket"
 
 logout_icon_color:
   default: "var(--primary-medium)"


### PR DESCRIPTION
Font Awesome 6 has replaced Font Awesome 5 and as such a number of icons
have new names: sign-out-alt is now known as right-from-bracket.